### PR TITLE
Modified policy to include access to TenureInformation table in DynamoDB

### DIFF
--- a/terraform/development-ecs-task/iam_role.tf
+++ b/terraform/development-ecs-task/iam_role.tf
@@ -22,6 +22,18 @@ resource "aws_iam_policy" "lambda_dynamodb_sns_policy" {
         {
             "Effect": "Allow",
             "Action": [
+                        "dynamodb:BatchGet*",
+                        "dynamodb:DescribeStream",
+                        "dynamodb:DescribeTable",
+                        "dynamodb:Get*",
+                        "dynamodb:Query",
+                        "dynamodb:Scan"
+                     ],
+            "Resource": "arn:aws:dynamodb:eu-west-2:${data.aws_caller_identity.current.account_id}:table/TenureInformation"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "ecr:GetAuthorizationToken",
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-979

## Describe this PR

### *What is the problem we're trying to solve*

Sync tenure data from DynamoDB to ES.

### *What changes have we introduced*

* Renamed Tenure domain to be TenureForPerson as it is just a subset of tenure data that is used in Person.
* Added the main Tenure domain with it's sub domains (PersonForTenure, AssetForTenure and TenureType).
* Added the use case for tenure data sync.
* Updated policy to allow access to tenureInformation table in DynamoDB.
