### PR TITLE
Drop the explicit configuration for deprecated Remote Docker version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,7 @@ commands:
       - *attach_workspace
       - checkout
       - aws-cli/install
-      - setup_remote_docker:
-          version: 19.03.13
+      - setup_remote_docker
       - run:
           command: |
             aws ecr get-login-password --region $<<parameters.region>> --profile <<parameters.profile-name>> | docker login --username AWS --password-stdin $<<parameters.account-url>>


### PR DESCRIPTION
# What:
 - Bump the CCI Remote Docker setup to latest docker version.

# Why:
 - The `19.03.13` is long deprecated that's causing the CCI steps  to get rejected.

# Notes:
 - Whatever the reason was hard-coding a specific version (be it needless, or to get around some bug) is no longer relevant as the Cloud Resources for this application are getting decommissioned (see more in PR #46 ).

# Screenshots:
| The CCI issue rejecting workflow step | Pipeline halts as soon as problem step is reached |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/e28a840c-4c3e-48a0-834b-a1bb75561a62) | ![image](https://github.com/user-attachments/assets/f9c2e366-4662-4ee1-ac3c-e8114021eea4) |