### PR TITLE
version bump for serverless and node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,11 +175,11 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_14.x | bash -
+            curl -sL https://deb.nodesource.com/setup_20.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Build lambda
           command: |


### PR DESCRIPTION
# What:
- Bumped version of serverless and node to comply with compatibility.

# Why:
- Because Serverless failed to install in the CCI workflow after being merged to master branch.

# Notes:
- All other steps passed in **_'deploy-to-development'_** workflow.