### PR TITLE
Removed duplicate jobs and added name key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,7 @@ workflows:
                only: release
       - terraform-init-and-apply-to-production:
           requires:
-            - assume-role-production
+            - "Assume role for production (first instance)"
           filters:
             branches:
               only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,8 +419,8 @@ workflows:
       #         only: release
       - permit-production-release:
           type: approval
-          requires:
-            - deploy-to-staging
+          # requires:
+          #   - deploy-to-staging
       #       - ecr-build-and-push-image-production
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,8 +395,8 @@ workflows:
               only: release
       - permit-production-terraform-release:
           type: approval
-          requires:
-            - deploy-to-staging
+          # requires:
+          #   - deploy-to-staging
       - assume-role-production:
           name: "Assume role for production (first instance)"
           context: api-assume-role-housing-production-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,6 +398,7 @@ workflows:
           requires:
             - deploy-to-staging
       - assume-role-production:
+          name: "Assume role for production (first instance)"
           context: api-assume-role-housing-production-context
           requires:
               - permit-production-terraform-release
@@ -431,6 +432,14 @@ workflows:
       #     filters:
       #       branches:
       #         only: release
+      - assume-role-production:
+          name: "Assume role for production (second instance)"
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-terraform-release
+          filters:
+             branches:
+               only: release
       - deploy-to-production:
           requires:
             - permit-production-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,6 +408,7 @@ workflows:
       - terraform-init-and-apply-to-production:
           requires:
             - "Assume role for production (first instance)"
+            - "Assume role for production (second instance)"
           filters:
             branches:
               only: release
@@ -436,14 +437,13 @@ workflows:
           name: "Assume role for production (second instance)"
           context: api-assume-role-housing-production-context
           requires:
-              - permit-production-terraform-release
+              - permit-production-release
           filters:
              branches:
                only: release
       - deploy-to-production:
           requires:
-            - permit-production-release
-      #       - terraform-deploy-ecs-task-to-production
+            -  terraform-init-and-apply-to-production
           filters:
             branches:
               only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,6 @@ workflows:
       - terraform-init-and-apply-to-production:
           requires:
             - "Assume role for production (first instance)"
-            - "Assume role for production (second instance)"
           filters:
             branches:
               only: release
@@ -443,7 +442,7 @@ workflows:
                only: release
       - deploy-to-production:
           requires:
-            -  terraform-init-and-apply-to-production
+            -  "Assume role for production (second instance)"
           filters:
             branches:
               only: release


### PR DESCRIPTION
# What:
- Removed duplicate _'**assume-role-production**_' jobs from configuration
- Added name key to reference the use of the same job, twice in the same workflow.

# Why:
- Should remove all configuration clash and re-patch up the CCI pipeline.  